### PR TITLE
Modify the entity to fit the service

### DIFF
--- a/src/main/java/com/delta/delta/entity/Comment.java
+++ b/src/main/java/com/delta/delta/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.delta.delta.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -27,9 +28,15 @@ public class Comment {
     @JsonIgnoreProperties({"comments", "postLikes", "images"})
     private Post post;
 
+
+    // comment 부분은 POST 요청으로 requestbody로 처리하는 부분이 없고,
+    // 렌더링 할 user 정보가 필요한데, elementProps로 구성된 follow 객체는 ignore가 안됨
+
+    // 만약 comment 에 Requestbody POST 요청이 들어온다면, Include에 해당하는 이 직렬데이터를 넣어야함
+    // 추후 서비스 구체화 협의 후 코드를 결정하겠습니다.
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
-    @JsonIgnoreProperties({"posts", "comments", "postLikes", "commentLikes"})
+    @JsonIncludeProperties({"userId", "profileImage", "firstname" ,"lastname", "createdAt"})
     private User user;
 
     @Column(columnDefinition = "VARCHAR(200)", nullable = false)

--- a/src/main/java/com/delta/delta/entity/CommentLike.java
+++ b/src/main/java/com/delta/delta/entity/CommentLike.java
@@ -1,5 +1,6 @@
 package com.delta.delta.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,9 +20,10 @@ public class CommentLike {
     @Column(name = "user_commentlike_id")
     private Long userCommentlikeId;
 
+    //commentLike는 User 정보를 렌더링 할 일이 없다 생각들어 아예 직렬화 X
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
-    @JsonIgnoreProperties({"posts", "comments", "postLikes", "commentLikes"})
+    @JsonBackReference
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/delta/delta/entity/Post.java
+++ b/src/main/java/com/delta/delta/entity/Post.java
@@ -25,12 +25,12 @@ public class Post {
     @Column(name = "post_id")
     private Long postId;
 
+    // backReference 걸어서, ignore annotation은 필요없을 것 같아 지우고 테스트 하였습니다.
     @ManyToOne(
             fetch = FetchType.LAZY,
             optional = false
     )
     @JoinColumn(name = "user_id", nullable = false)
-    @JsonIgnoreProperties({"posts", "comments", "postLikes", "commentLikes"})
     @JsonBackReference
     private User user;
 

--- a/src/main/java/com/delta/delta/entity/PostLike.java
+++ b/src/main/java/com/delta/delta/entity/PostLike.java
@@ -1,6 +1,7 @@
 package com.delta.delta.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -27,9 +28,15 @@ public class PostLike {
     @JsonIgnoreProperties({"comments", "postLikes", "images"})
     private Post post;
 
+    // postLike 부분은 POST 요청을 requestbody로 처리하는 부분이 없고, (이러면 include 문제 X)
+    // 인스타그램 UI 상으로는 좋아요 목록을 보면 user 기본정보가 보여서 include로 구성
+    // elementProps로 구성된 follow 객체는 ignore가 안되서, 차집합으로 include로 사용
+
+    // 만약 postLike 에 Requestbody POST 요청이 들어온다면, Include한 이 직렬데이터를 넣어야함
+    // 추후 서비스 구체화 협의 후 코드를 결정하겠습니다.
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
-    @JsonIgnoreProperties({"posts", "comments", "postLikes", "commentLikes"})
+    @JsonIncludeProperties({"userId", "profileImage", "firstname" ,"lastname", "createdAt"})
     private User user;
 
     @CreationTimestamp

--- a/src/main/java/com/delta/delta/entity/User.java
+++ b/src/main/java/com/delta/delta/entity/User.java
@@ -1,5 +1,6 @@
 package com.delta.delta.entity;
 
+import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,14 +32,18 @@ public class User implements UserDetails {
     private LocalDateTime createdAt = LocalDateTime.now();
     private LocalDateTime updatedAt;
 
+    // postLike, comment와 동일한 논리로 인해 include 도입
     @ElementCollection
     @CollectionTable(name = "user_followers", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "follower_id")
+    @JsonIncludeProperties({"userId", "username", "firstname", "lastname", "profileImage"})
     private Set<Long> followers = new HashSet<>();
+
 
     @ElementCollection
     @CollectionTable(name = "user_followings", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "following_id")
+    @JsonIncludeProperties({"userId", "username", "firstname", "lastname", "profileImage"})
     private Set<Long> followings = new HashSet<>();
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)


### PR DESCRIPTION
### 개요

프론트 디자인 프로토타입 (figma) + 백엔드 코드 흐름 + SNS UI 참고(instagram) 등을 고려하여 entity의 직렬화 참조관계를 구성하였습니다.

### 내용
 
대부분은 JsonIgnoreAnnotation으로 직렬화를 선택적으로 막았으나, element객체로 구성된 followings, followers는 JsonignoreAnnotation이 선택적으로 인식하여 어노테이션 기능이 활성화 되지 못합니다.

> @ElementCollection은 엔티티 내부에 기본 타입 컬렉션을 저장할 때 사용하며, Hibernate는 이를 별도의 테이블로 관리합니다. 따라서 @JsonIgnoreProperties는 엔티티 필드에만 적용되므로, followers 필드에는 영향을 미치지 않습니다.

그렇기에, user를 참조하는 상황이 온다면, backreference로 아예 막거나, include로 follow를 베재해야 한다고 판단하였습니다.
하지만 include는 Method:Post 상황에서는, 이 include로 정의한 데이터를 넣어서 보내주어야 하므로, 개발 단계에서 큰 제약조건으로 작용할 수 있습니다.

결론적으로, POST METHOD에 RequestBody를 요청하지 않는 상황 && USER 정보는 꼭 넣으면 좋겠다(여러분들의 코드를 보고 최대한 반영하려 노력) 라는 상황에선 INCLUDE를 적용하였습니다.

그렇지 않은 상황에선 USER 전체를 ignore 하는 상황으로 구성하였습니다 <commentLike에선, user 정보가 굳이..?>

의견이 있으시면 자유로이 말씀해 주세요 ! 
그리고 어차피 고치는건 쉬워서 괜찮습니다. 이제 백엔드는 거의 고정상태니까요.